### PR TITLE
DevToEval: set "sameSite:none" and "secure:true" in cookie 

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -5,7 +5,7 @@
   "env": {
     "NODE_ENV": "development",
     "PORT": 1111,
-    "BASE_GROUP": "uw_event_ws-eval_",
+    "BASE_GROUP": "uw_event_dev_",
     "SESSIONKEY": "development",
     "GRAPHITE_HOSTNAME": "it-wsapp1.s.uw.edu",
     "GRAPHITE_PREFIX": "test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uwer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "npm": "6.14.4",
     "node": "14.11.0"

--- a/src/backend/controllers/frontend.js
+++ b/src/backend/controllers/frontend.js
@@ -44,8 +44,8 @@ if (NODE_ENV === 'development') {
 app.get(
   Routes.Login,
   function(req, res, next) {
-    console.log(`Login: set cookie authRedirectUrl= ${req.query.returnUrl}`);
-    res.cookie('authRedirectUrl', req.query.returnUrl, { ...uwerSetCookieDefaults, signed: false, maxAge: 5 * 60 * 1000 });
+    res.cookie('authRedirectUrl', req.query.returnUrl, { ...uwerSetCookieDefaults, signed: false, maxAge: 5 * 60 * 1000, sameSite: 'none', secure: true});
+    console.log(`Login: set cookie: 'authRedirectUrl', ${req.query.returnUrl}, {... uwerSetCookieDefaults, signed: false, maxAge: 5 * 60 * 1000, sameSite: 'none', secure: true}`);
     next();
   },
   passport.authenticate('saml', { failureRedirect: Routes.Welcome, failureFlash: true })

--- a/src/backend/controllers/frontend.js
+++ b/src/backend/controllers/frontend.js
@@ -44,6 +44,7 @@ if (NODE_ENV === 'development') {
 app.get(
   Routes.Login,
   function(req, res, next) {
+    console.log(`Login: set cookie authRedirectUrl= ${req.query.returnUrl}`);
     res.cookie('authRedirectUrl', req.query.returnUrl, { ...uwerSetCookieDefaults, signed: false, maxAge: 5 * 60 * 1000 });
     next();
   },

--- a/src/backend/controllers/frontend.js
+++ b/src/backend/controllers/frontend.js
@@ -45,7 +45,6 @@ app.get(
   Routes.Login,
   function(req, res, next) {
     res.cookie('authRedirectUrl', req.query.returnUrl, { ...uwerSetCookieDefaults, signed: false, maxAge: 5 * 60 * 1000, sameSite: 'none', secure: true});
-    console.log(`Login: set cookie: 'authRedirectUrl', ${req.query.returnUrl}, {... uwerSetCookieDefaults, signed: false, maxAge: 5 * 60 * 1000, sameSite: 'none', secure: true}`);
     next();
   },
   passport.authenticate('saml', { failureRedirect: Routes.Welcome, failureFlash: true })

--- a/src/backend/utils/helpers.js
+++ b/src/backend/utils/helpers.js
@@ -39,6 +39,7 @@ const devModeAuthenticated = req => {
 
 export const backToUrl = (url = Routes.Register) => {
   return function(req, res) {
+    console.log(`backToUrl: cookie authRedirectUrl: ${req.cookies.authRedirectUrl}`);
     res.redirect(req.cookies.authRedirectUrl || Routes.Register);
   };
 };


### PR DESCRIPTION
set "sameSite:none" and "secure:true" in the response cookie in /login in order for the browser to load cookie "authRedirectUrl" in following cross-site  requests. This cookie "authRedirectUrl" is used for callback returned URL after passport-saml authentication call. Without sameSite cookie, "authRedirectUrl" is not loaded to the cross-site request due to the default behavior of "sameSite" policy was changed, so that it goes to the default URL: /register, which is not expected.